### PR TITLE
feat: add digital clock logic

### DIFF
--- a/js/modules/clock.js
+++ b/js/modules/clock.js
@@ -55,7 +55,23 @@ function rotateHoursHand() {
   hour.style.transform = `translate(-50%, -100%) rotate(${hourDegrees}deg)`;
 }
 
+function initDigitalClock() {
+  setInterval(() => {
+    const currentHour =
+      new Date().getHours() > 12
+        ? String(new Date().getHours() - 12).padStart(2, "0")
+        : String(new Date().getHours()).padStart(2, "0");
+    const currentMinute = String(new Date().getMinutes()).padStart(2, "0");
+    const isAM = new Date().getHours() < 12;
+
+    digitalTime.innerHTML = `${currentHour}:${currentMinute} <span class="clock__am-pm">${
+      isAM ? "AM" : "PM"
+    }</span>`;
+  }, 1000);
+}
+
 export function initClock() {
   displayInitialTime();
   rotateSecondsHand();
+  initDigitalClock();
 }


### PR DESCRIPTION
## Description

Added the digital clock feature logic to the widget. Cleaned up initial debug logs. Added as  a complement for the analog clock.

## Changes

- Added logic to display current time on the digital clock  
- Selected the digital clock element from the DOM  
- Removed extra console logs for a cleaner console output  

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Before screenshot](https://github.com/user-attachments/assets/57e9cf74-acb1-4961-8960-accd76ce177f) | ![After screenshot](https://github.com/user-attachments/assets/b942bd33-fc6a-4ca1-a370-03f3f391eca6) |

## Notes for Reviewers

- Ensure the digital clock displays accurate time on load and updates correctly before merging
