### PR TITLE
fix(js): fix hour showing double zero instead of twelve when its midn…

### DIFF
--- a/js/modules/clock.js
+++ b/js/modules/clock.js
@@ -84,7 +84,9 @@ function initDigitalClock() {
     const currentHour =
       new Date().getHours() > 12
         ? String(new Date().getHours() - 12).padStart(2, "0")
-        : String(new Date().getHours()).padStart(2, "0");
+        : String(
+            new Date().getHours() === 0 ? 12 : new Date().getHours()
+          ).padStart(2, "0");
     const currentMinute = String(new Date().getMinutes()).padStart(2, "0");
     const isAM = new Date().getHours() < 12;
 


### PR DESCRIPTION
## Description

Fixed the digital clock showing for midnight.

## Changes

- Changed digital clock to show `12:00 AM` instead pf `00:00 AM` at midnight

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Before screenshot](https://github.com/user-attachments/assets/5fce60b5-a65a-4f67-9ece-bb34cb3d63ca) | ![After screenshot](https://github.com/user-attachments/assets/ca19e7f4-f2c8-4d16-bec1-e2188fae5427) |

## Notes for Reviewers

- Quick fix, merge as soon as possible

